### PR TITLE
Compatible with Elephant.io 4.7

### DIFF
--- a/ElephantIo.php
+++ b/ElephantIo.php
@@ -3,7 +3,6 @@ namespace sammaye\elephantio;
 
 use yii\base\Component;
 use ElephantIO\Client;
-use ElephantIO\Engine\SocketIO\Version2X;
 
 class ElephantIo extends Component
 {
@@ -20,8 +19,8 @@ class ElephantIo extends Component
 
 		$host = $this->host;
 
-		$this->_client = new Client(new Version2X(is_callable($host) ? $host() : $host, $this->options));
-		$this->_client->initialize();
+		$this->_client = Client::create($host, $this->options);
+		$this->_client->connect();
 	}
 
 	public function emit($event, $params = [], $namespace = null)

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 	},
 	"require": {
 		"php": ">=5.4.0",
-		"wisembly/elephant.io": "*"
+		"elephantio/elephant.io": "^4.7"
 	},
 	"autoload": {
 		"psr-4": {"sammaye\\elephantio\\": ""}


### PR DESCRIPTION
The client version can now be configured using options: ['client' => Client::CLIENT_4X]